### PR TITLE
terminate fix: calling from multiple coroutines

### DIFF
--- a/aioscript.py
+++ b/aioscript.py
@@ -26,6 +26,7 @@ class AbstractScript(metaclass=abc.ABCMeta):
     periodic_task = None
 
     def __init__(self):
+        self._terminating = False
         parser = self.setup_parser()
 
         self.options = self.setup_options(
@@ -214,7 +215,9 @@ class AbstractScript(metaclass=abc.ABCMeta):
         Terminate running script. Kill all workers.
         :return:
         """
-        self.loop.call_soon(partial(os.kill, os.getpid(), signal.SIGINT))
+        if not self._terminating:
+            self._terminating = True
+            self.loop.call_soon(partial(os.kill, os.getpid(), signal.SIGINT))
 
         return self.loop.create_future()
 

--- a/tests/test_aioscript.py
+++ b/tests/test_aioscript.py
@@ -129,8 +129,7 @@ def test_script_terminated():
                 yield i
 
         async def handle(self, data):
-            if data == 3:
-                await self.terminate()
+            await self.terminate()
 
         async def done(self):
             check.append(DONE)


### PR DESCRIPTION
fix problem that terminate method can be called from multiple coroutines and as a result, it tries to kill current python process multiple times.
Added flag `_terminating`.